### PR TITLE
Add toggle to turn off `strip_accents`.

### DIFF
--- a/build_openwebtext_pretraining_dataset.py
+++ b/build_openwebtext_pretraining_dataset.py
@@ -30,7 +30,8 @@ def write_examples(job_id, args):
       output_dir=os.path.join(args.data_dir, "pretrain_tfrecords"),
       max_seq_length=args.max_seq_length,
       num_jobs=args.num_processes,
-      blanks_separate_docs=False
+      blanks_separate_docs=False,
+      strip_accents=args.strip_accents,
   )
   log("Writing tf examples")
   fnames = sorted(tf.io.gfile.listdir(owt_dir))
@@ -65,6 +66,14 @@ def main():
                       help="Number of tokens per example.")
   parser.add_argument("--num-processes", default=1, type=int,
                       help="Parallelize across multiple processes.")
+
+  # toggle strip-accents and set default to True which is the default behavior
+  parser.add_argument("--do-strip-accents", dest='strip_accents',
+                      action='store_true', help="Strip accents (default).")
+  parser.add_argument("--no-strip-accents", dest='strip_accents',
+                      action='store_false', help="Don't strip accents.")
+  parser.set_defaults(strip_accents=True)
+
   args = parser.parse_args()
 
   utils.rmkdir(os.path.join(args.data_dir, "pretrain_tfrecords"))

--- a/build_pretraining_dataset.py
+++ b/build_pretraining_dataset.py
@@ -103,11 +103,12 @@ class ExampleWriter(object):
   """Writes pre-training examples to disk."""
 
   def __init__(self, job_id, vocab_file, output_dir, max_seq_length,
-               num_jobs, blanks_separate_docs, num_out_files=1000):
+               num_jobs, blanks_separate_docs, num_out_files=1000, strip_accents=True):
     self._blanks_separate_docs = blanks_separate_docs
     tokenizer = tokenization.FullTokenizer(
         vocab_file=vocab_file,
-        do_lower_case=True)
+        do_lower_case=True,
+        strip_accents=strip_accents)
     self._example_builder = ExampleBuilder(tokenizer, max_seq_length)
     self._writers = []
     for i in range(num_out_files):
@@ -154,7 +155,8 @@ def write_examples(job_id, args):
       output_dir=args.output_dir,
       max_seq_length=args.max_seq_length,
       num_jobs=args.num_processes,
-      blanks_separate_docs=args.blanks_separate_docs
+      blanks_separate_docs=args.blanks_separate_docs,
+      strip_accents=args.strip_accents,
   )
   log("Writing tf examples")
   fnames = sorted(tf.io.gfile.listdir(args.corpus_dir))
@@ -189,6 +191,14 @@ def main():
                       help="Parallelize across multiple processes.")
   parser.add_argument("--blanks-separate-docs", default=True, type=bool,
                       help="Whether blank lines indicate document boundaries.")
+
+  # toggle strip-accents and set default to True which is the default behavior
+  parser.add_argument("--do-strip-accents", dest='strip_accents',
+                      action='store_true', help="Strip accents (default).")
+  parser.add_argument("--no-strip-accents", dest='strip_accents',
+                      action='store_false', help="Don't strip accents.")
+  parser.set_defaults(strip_accents=True)
+
   args = parser.parse_args()
 
   utils.rmkdir(args.output_dir)

--- a/model/tokenization.py
+++ b/model/tokenization.py
@@ -99,10 +99,16 @@ def whitespace_tokenize(text):
 class FullTokenizer(object):
   """Runs end-to-end tokenziation."""
 
-  def __init__(self, vocab_file, do_lower_case=True):
+  def __init__(self, vocab_file, do_lower_case=True, strip_accents=True):
+    """Constructs a FullTokenizer.
+    Args:
+      vocab_file: The vocabulary file.
+      do_lower_case: Whether to lower case the input.
+      strip_accents: Whether to strip the accents.
+    """
     self.vocab = load_vocab(vocab_file)
     self.inv_vocab = {v: k for k, v in self.vocab.items()}
-    self.basic_tokenizer = BasicTokenizer(do_lower_case=do_lower_case)
+    self.basic_tokenizer = BasicTokenizer(do_lower_case=do_lower_case, strip_accents=strip_accents)
     self.wordpiece_tokenizer = WordpieceTokenizer(vocab=self.vocab)
 
   def tokenize(self, text):
@@ -123,13 +129,15 @@ class FullTokenizer(object):
 class BasicTokenizer(object):
   """Runs basic tokenization (punctuation splitting, lower casing, etc.)."""
 
-  def __init__(self, do_lower_case=True):
+  def __init__(self, do_lower_case=True, strip_accents=True):
     """Constructs a BasicTokenizer.
 
     Args:
       do_lower_case: Whether to lower case the input.
+      strip_accents: Whether to strip the accents.
     """
     self.do_lower_case = do_lower_case
+    self.strip_accents = strip_accents
 
   def tokenize(self, text):
     """Tokenizes a piece of text."""
@@ -149,7 +157,8 @@ class BasicTokenizer(object):
     for token in orig_tokens:
       if self.do_lower_case:
         token = token.lower()
-        token = self._run_strip_accents(token)
+        if self.strip_accents:
+            token = self._run_strip_accents(token)
       split_tokens.extend(self._run_split_on_punc(token))
 
     output_tokens = whitespace_tokenize(" ".join(split_tokens))


### PR DESCRIPTION
In some languages like German the accents are important and change the sementics. Examples:

1. mochte vs. möchte
2. musste vs. müsste
3. etc.

But when doing `lower_case` they are automatically always stripped.

This PR adds a toggle to make it possible to do `lower_case` but keep the accents. This conforms to the `transformers.tokenization_bert.BertTokenizerFast` which also has an boolean parameter called `strip_accents`.

With default parameters this PR introduces no breaking change because we init `strip_accents`with `True` which is the default behavior.

This PR is basicaly a copy of this PR coming from Electra. Its got merged some days ago: https://github.com/google-research/electra/pull/88

More about accents and the samentic can be seen in this video about our [German Electra model](https://huggingface.co/german-nlp-group/electra-base-german-uncased):\
https://youtu.be/cxgrTd2AQis?t=969